### PR TITLE
docs(postgresql): CPU 100% 재현 및 원인 분석 — 커넥션 churn/재시도 나선 실측

### DIFF
--- a/postgresql/cpu100-connection-churn-reproduction.md
+++ b/postgresql/cpu100-connection-churn-reproduction.md
@@ -1,0 +1,287 @@
+# PostgreSQL CPU 100% 재현 및 원인 분석
+
+- Date: 2026-07-31 | Region: koreacentral | Target: Azure Database for PostgreSQL Flexible Server (D4ds_v5)
+- Scope: 운영 관측(CPU 100%, 세션 ~5,000, write-only 로그)과 동일 조건 재현 및 원인 가설 검증. 특정 재현 환경 실측값이며 프로덕션 확정 진단 아님.
+
+## 배경
+
+- 운영 서비스는 세션정보·로그를 PostgreSQL(Azure Flexible Server, **4 vCore/16GiB**)에 기록하는 write 중심 워크로드 (Python + psycopg 클라이언트, key-value/log/sorted-set 형태의 store 테이블 4종에 INSERT/UPSERT)
+- 어느 시점 **DB CPU가 100%로 포화**되어 장애 발생 → **8 vCore로 증설하자 안정화**됐으나 원인은 미규명
+- 이상한 점: 장애 당시 쿼리 로그에는 **INSERT/UPSERT만 평균 ~22 QPS** — CPU를 태울 만한 부하가 아님. 그런데 세션은 ~5,000개, 메모리는 50%대로 오히려 안정
+- "적은 쿼리 + 많은 세션 + 안정적 메모리 + CPU 100%"의 조합이 어떻게 성립하는지 확인하기 위해, **동일 사양·스키마·데이터 규모의 재현 환경**에서 원인 후보를 하나씩 실측 검증한 기록
+
+> **요약**
+> - 재현 환경: 운영과 동일 스키마·데이터·사양 (D4ds, 4 vCore/16GiB)
+> - 실측 결과: **커넥션 수립(backend fork + TLS 핸드셰이크) 비용 폭주(재시도 나선)**가 운영 관측 4종
+>   (CPU 100% / 세션 ~5,000 / 메모리 50%대 안정 / 로그엔 INSERT ~20 QPS만)과 모두 일치하는 상태를 재현
+> - 이를 최유력 가설로 두고, 원인 후보 전체를 검증 우선순위(§0)로 정리
+> - 프로덕션 코드·연결 경로의 실제 확인 항목은 각 가설에 병기
+
+---
+
+## 0. 원인 후보 및 검증 우선순위
+
+재현 실측 결과에 근거한 검증 우선순위:
+
+| 순위 | 가설 | 근거 (재현 실험) | 운영에서 확인할 것 |
+|:---:|------|----------------|------------------|
+| **1** | **per-request connect + 재시도 나선** (psycopg 기본 사용, 요청/태스크마다 connect) | §3.1: 운영 규모 부하(200 tasks/s)로 CPU 99.2%, 세션 수천, 메모리 안정, INSERT 소량 성사 — 관측 4종과 모두 일치 | 코드에서 `psycopg2.connect(`가 핸들러/태스크/루프 안에 있는지. 재시도 로직에 backoff가 없는지 |
+| **2** | **Pool thrashing** (풀은 있으나 minIdle 낮음/idleTimeout 짧음 + 버스트) | §3.3: 풀 존재 상태에서 CPU 96%, backend_start<10s 비율 96% | 풀 설정(minIdle, idleTimeout). `pg_stat_activity`에서 young 백엔드 비율 |
+| **3** | **앱이 PgBouncer(6432)가 아닌 5432로 직결** | §3.5: 같은 폭풍이 5432=99.7% vs 6432=18.6% — 6432였다면 CPU 양상이 달랐을 것 | 앱 연결 문자열의 포트. `pg_stat_activity`의 client_addr |
+| 4 | autovacuum/bloat 증폭 | §4: 가동 시 +25~30%p, 단독으론 100% 미도달 | offsets 테이블 bloat 비율, autovacuum 로그 |
+| 5 | 핫로우 동시 경합 (offsets ON CONFLICT) | §4: 수백 active 시 CPU 96% — 나선 정착 후의 2차 양상일 가능성 | 장애 시점 active 세션 수와 wait_event |
+| 6 | 논리복제/CDC (미검증) | 쿼리 로그의 `seq_counter`가 CDC 흔적일 가능성. 물리 replica는 무해 확인(§4) | `pg_replication_slots WHERE slot_type='logical'` |
+
+기각된 가설은 §6 참고.
+
+---
+
+## 1. 운영 장애 관측
+
+| # | 관측 | 값 |
+|---|------|-----|
+| O1 | CPU | 4 vCore에서 100% → 8 vCore 증설로 안정화 |
+| O2 | PostgreSQL 세션 수 | ~5,000개 |
+| O3 | 메모리 | 50%대로 안정 |
+| O4 | 쿼리 로그 | **INSERT/UPSERT만** 존재 (SELECT 없음), 평균 ~22 QPS, 버스트 80~150 ops/s |
+| O5 | 클라이언트 | **Python + psycopg** |
+| O6 | 기타 | read replica 존재, PgBouncer 활성화 상태였음 |
+
+## 2. 재현 환경
+
+| 항목 | 값 |
+|------|-----|
+| 서버 | Azure Database for PostgreSQL Flexible Server (Korea Central) |
+| SKU | **Standard_D4ds_v5 (4 vCore / 16 GiB)** — 운영 장애 당시와 동일 |
+| 버전 | PostgreSQL 16.14 |
+| 스토리지 | 256 GiB |
+| PgBouncer | 내장, port 6432, transaction mode, `default_pool_size=50` |
+| 스키마 | 운영 스키마 DDL(`schema.sql`) — store 4테이블, 월별 파티션 38개, 인덱스 198개 |
+| 데이터 | **48M+ rows / ~74 GB** (운영 파티션별 통계 목표치 충족, bytea 1.2~1.8KB 페이로드로 TOAST 비중 재현) |
+| 부하 도구 | Python 3.9 + psycopg2 (운영과 동일 스택), macOS 클라이언트에서 직접 실행 |
+
+---
+
+## 3. CPU 100% 재현 시나리오
+
+> ※ 재현 환경에서의 결과. 운영 관측과의 일치 = 정황 근거. 프로덕션 실제 경로 여부는 §0 확인 항목으로 검증.
+
+### 3.1 재시도 나선(retry spiral) — 20 QPS 수준 부하, CPU 99.2%
+
+운영의 "부하는 겨우 20 QPS였는데 왜?"라는 의문에 대한 유력한 설명 후보. **재현 실험 중 작은 부하로 CPU 100%에 도달한 유일한 시나리오.**
+
+**조건**
+- 제공 부하: 태스크 200개/s (운영 버스트 150 ops/s와 같은 자릿수), 태스크당 INSERT 1건
+- 클라이언트 동작: per-request `psycopg2.connect(connect_timeout=5)` → INSERT → `close()`, 연결 실패 시 즉시 2회 재시도 (지극히 평범한 앱 코드)
+- 프로세스 5개 × 40 tasks/s, 프로세스당 in-flight 상한 1,500
+
+**결과**
+
+| 지표 | 값 | 운영 관측 대응 |
+|------|-----|--------------|
+| 서버 CPU | **99.2%** | O1 ✅ |
+| 클라이언트 대기 커넥션 | **7,500개 포화** | O2 ✅ (세션 = 대기 행렬) |
+| 메모리 | 39% 안정 | O3 ✅ (단명 세션은 누적 안 됨) |
+| **성사된 INSERT** | **~2/s** (재시도 92,000회+, 포기 28,000+) | O4 ✅ (로그엔 성사분만 기록) |
+
+**메커니즘 (수식)**: `동시 커넥션 = 시도율 × 연결 소요시간`
+- 정상: 200/s × 0.1s = 20개
+- 나선: 연결 지연 5s+ → 타임아웃 → 재시도로 시도율 3배 증폭 → 600/s × 8s = **수천 개**
+
+**8 vCore 증설 즉효와의 정합성**: fork/TLS 처리 용량 2배 → 연결 지연 해소 → 나선의 고리(지연→재시도→지연) 차단 → 같은 20 QPS로 복귀. 운영의 "증설 즉시 안정화" 경과와 일치. 단, 이 경우 원인은 해소가 아니라 잠복.
+
+### 3.2 커넥션 churn — 동시 커넥터 480, CPU 99.7%
+
+**조건**: 동시 커넥터 480개(8프로세스×60스레드)가 `connect(TLS+fork) → INSERT 1건 → close` 반복. 직접 5432.
+
+**결과**: CPU **99.4~99.7% 지속**(4분+), 메모리 40%대 안정, 연결 성사 ~125/s뿐, 연결 소요 평균 **3.4초**(정상 ~0.1초).
+재현 환경에서 쿼리가 아니라 **연결 수립 비용만으로 4코어가 포화됨**을 처음 확인한 실험.
+
+### 3.3 Pool thrashing — 풀 구성 상태에서 CPU 96%
+
+"커넥션 풀이 있는데도 발생할 수 있는가?"에 대한 검증.
+
+**조건**: HikariCP류 흔한 설정 시뮬레이션 — `minimumIdle=0`, 짧은 `idleTimeout` + 운영 트래픽의 버스트 패턴(4초 burst/12초 주기). 앱 인스턴스 60개 × pool max 20.
+
+**결과**: CPU **94~97.7%** (10분+), 메모리 46% 안정, 연결 개폐 ~95/s(opened=evicted 대칭), 백엔드 341~398개 중 **96%가 backend_start 10초 미만**.
+버스트마다 풀이 0→20 새 연결, 조용해지면 전부 반납 → 풀이 스스로 churn을 만든다.
+
+**운영 진단 쿼리** (1분 확인):
+```sql
+SELECT count(*) AS total,
+       count(*) FILTER (WHERE now()-backend_start < interval '10 s') AS young
+FROM pg_stat_activity;
+-- young/total 비율이 높으면 churn/thrashing 가능성이 높음
+```
+
+### 3.4 psycopg 연결 패턴 비교 — per-request vs 재사용
+
+**조건**: 동일 워커 30개, 동일 UPSERT, 각 90초. (a) per-request connect vs (b) 연결 재사용.
+
+| 패턴 | 처리량 | 서버 CPU | op당 CPU 비용 |
+|------|-------:|---------:|:---:|
+| `psycopg2.connect()` per-request | 101 ops/s | **93~96%** | **~7배** |
+| 연결 재사용 (풀 동등) | 542 ops/s | 69~75% | 1x |
+
+psycopg는 **기본 풀이 없다** — Python 앱에서 흔한 per-request connect 패턴이 §3.2의 churn과 동일한 부하를 만든다.
+
+### 3.5 PgBouncer 경유 비교 — 5432 vs 6432
+
+**조건**: 3.2와 완전히 동일한 480 커넥터 churn을 6432(내장 PgBouncer)로.
+
+| 지표 | 직접 5432 | PgBouncer 6432 |
+|------|----------|----------------|
+| 서버 CPU | **99.7%** | **10~18.6%** |
+| PG 백엔드 | 수백 (계속 fork) | **112개 고정** (재사용) |
+| 연결 소요 | 3.4s | 1.4~1.9s |
+
+**시사점**
+- 재현 환경 기준, 6432 경유 시 같은 churn에서 CPU 100% 미도달 → 운영 앱의 5432 직결 가능성 시사 (실제 경로는 §0 순위 3으로 확인)
+- 6432도 연결 지연(싱글스레드 PgBouncer의 TLS 병목)은 잔존 → 근본 대책은 앱 풀
+
+### 3.6 인과 사슬
+
+```
+[평시] Python 앱(psycopg, per-request connect 또는 thrashing 풀) + ~22 QPS
+[트리거] 순간 버스트/일시 지연으로 연결 소요시간 상승
+[나선] 연결 지연 → connect_timeout → 재시도 → 시도율 증폭 → 지연 악화 → …
+[정착] CPU 100% (fork+TLS 소진), 세션 수천(대기 행렬), INSERT는 ~20/s만 성사
+[관측] 로그: INSERT만 소량 | 세션: ~5,000 | 메모리: 안정 | CPU: 100%
+[해소] 8 vCore: 연결 처리 용량 2배 → 나선 붕괴 → 정상 복귀 (원인 존치)
+```
+
+---
+
+## 4. 보조 발견
+
+| 발견 | 실측 | 의미 |
+|------|------|------|
+| autovacuum 비용 | 가동 순간 동일 부하에서 CPU +25~30%p (시딩 직후 단독 96%) | 나선 발생 시 증폭기. offsets 테이블은 운영에서 2배 bloat 상태 |
+| 동시 active 세션 경합 | 직접접속 355 active → CPU 96%, 처리량 1/3 붕괴 | 나선 정착 후의 2차 양상 (핫로우 `store_stream_offsets` ON CONFLICT 경합) |
+| 세션 폭주 → 관리 불능 | 메모리 고갈 시 Azure 컨트롤플레인 API 전체 실패, stop/start만 복구 가능 (다운타임 ~40분) | 운영 재발 시 **장애 대응 조작이 안 되는 이중 장애** 위험 |
+| 16GB의 세션 한계 | 오래 사는 백엔드는 ~2,000개에서 OOM (SSL 유무 무관) | "세션 5,000"은 오래 사는 백엔드가 아니라 단명 세션의 스냅샷일 가능성을 뒷받침 |
+
+## 5. 권장 대책
+
+| # | 조치 | 근거 |
+|---|------|------|
+| 1 | **앱에 커넥션 풀 도입** — psycopg2 `ThreadedConnectionPool` / psycopg3 `psycopg_pool`. 풀 사용 시 `minIdle=maxSize`로 고정해 thrashing 방지 | §3.4: 같은 하드웨어에서 5.4배 처리량, CPU는 더 낮음 |
+| 2 | **연결 문자열 포트 5432 → 6432** (내장 PgBouncer) | §3.5: 같은 폭풍이 99.7% → 18.6% |
+| 3 | **재시도에 exponential backoff + jitter** — 즉시 재시도가 나선의 증폭 계수 | §3.1: 즉시 재시도가 시도율 3배 증폭 |
+| 4 | `log_connections=on` + 연결 rate/소요시간 알람 | 나선은 초기에 끊으면 수 초에 풀림 |
+| 5 | offsets 핫로우 배치 flush + autovacuum 튜닝(fillfactor) | §4: 증폭 요인 제거 |
+| 6 | in-memory/Redis/PG 3중 기록 제거 (아키텍처) | write 볼륨 자체 감축 |
+
+### PgBouncer 사용 시 주의
+transaction mode에서는 세션 상태 의존 기능(SET, prepared statements, advisory lock)이 트랜잭션 스코프로 제한됨. 이 워크로드(단발 INSERT/UPSERT)는 해당 없음.
+
+---
+
+## 6. 기각된 가설
+
+원조건과 다른 조건에서만 성립했거나, 운영 증거에 의해 기각된 시나리오. 탐색 과정의 기록으로 남긴다.
+
+<details>
+<summary><b>기각 1) 기록된 쿼리 믹스 단독 부하</b></summary>
+
+**조건**: 운영 1시간 쿼리 로그의 쿼리 믹스(INSERT/UPSERT/DELETE 8종)를 PgBouncer 경유로 1배~175배(3,900 QPS)까지 증폭. 풀 방식(연결 재사용) 클라이언트.
+
+**결과**: 175배에서도 CPU **최대 49%**. 깨끗한 동일 스키마·동일 수량 DB에서 기록된 쿼리는 아무리 부어도 4 vCore를 포화시키지 못함.
+
+**교훈**: 관건은 "무슨 쿼리를 얼마나"가 아니라 "어떻게 연결해서".
+</details>
+
+<details>
+<summary><b>기각 2) 미기록 SELECT 트래픽 (운영 로그에 SELECT 부재로 기각)</b></summary>
+
+**조건**: 세션 저장소형 read 믹스(kv point GET + sorted_set range + log tail + 30% write)를 ~810 QPS로 실행.
+
+**결과**: CPU 22%. 이후 scope prefix 스캔(`LIKE 'ns:x%'`, 파티션 프루닝 불가)은 ~1,170 QPS에서 CPU 58~67%로 유력해 보였고, VACUUM과 겹치면 95.3%까지 도달했다.
+
+**기각 사유**: 운영 측이 **장애 서버 로그에 SELECT가 전혀 없음**을 확인. prefix 스캔 시나리오는 조건 자체가 성립하지 않음. (단, `text_pattern_ops` 인덱스 4개가 스키마에 존재하므로 이 쿼리 패턴이 어딘가에 있다면 잠재 위험은 유효)
+</details>
+
+<details>
+<summary><b>기각 3) 세션 누적에 의한 메모리 고갈 (운영 메모리 안정 관측과 불일치)</b></summary>
+
+**조건**: (a) 스레드 기반 5,000 세션 시도, (b) psycopg2 ThreadedConnectionPool 50인스턴스×100.
+
+**결과**: (a) ~1,900개에서 memory 39→89%, OOM으로 **서버 실제 다운** (restart API도 실패, stop/start로 40분 복구). (b) 2,716개에서 고착(mem 80%), +write 시 CPU 70.7% + 쿼리 OOM.
+
+**정정 사유**: 운영은 **메모리가 50%대로 안정**이었다고 확인됨 → "RAM 잠식" 모델은 관측과 모순. 이 실험이 남긴 유효한 결론은 "16GB에 오래 사는 백엔드 5,000개는 물리적으로 불가"이며, 이것이 역으로 **세션 5,000 = 단명 세션 스냅샷** 가설(§3.1에서 재현 성립 확인)로 이어짐.
+</details>
+
+<details>
+<summary><b>기각 4) idle 세션 대량 유지의 CPU 오버헤드</b></summary>
+
+**조건**: 쿼리 없는 idle 홀더로 세션만 유지. D4ds(16GB)에서 ~2,000개(한계), E4ds(4c/32GB)로 올려 4,814개 + write 부하.
+
+**결과**: idle 4,800개 유지 시 CPU **~11%**. +write 부하(~1,000 QPS)에도 max 40.7%. 4,800세션이 각자 1~5초 간격으로 write해도 14~40%.
+
+**교훈**: idle 세션은 CPU 무해(스냅샷 오버헤드 미미). "세션이 많다" 자체가 아니라 "세션이 계속 만들어진다"가 문제.
+</details>
+
+<details>
+<summary><b>기각 5) PostgreSQL 버전(13 vs 16) / SSL 강제 여부</b></summary>
+
+**조건**: PG13.23 + `require_secure_transport=off` 서버를 별도 구축(D4ds), 동일 스키마/시드 후 비-SSL 세션 폭주.
+
+**결과**: 비-SSL이어도 세션당 메모리 유사, ~2,970개에서 `could not fork: Cannot allocate memory`. CPU는 7%뿐이고 OOM 1,598건 — PG16과 유의미한 차이 없음.
+
+**교훈**: 버전/SSL 설정은 무관. (단 TLS 핸드셰이크 자체는 churn 비용의 일부로 §3.2에서 유효)
+</details>
+
+<details>
+<summary><b>기각 6) read replica의 primary 부하</b></summary>
+
+**조건**: 운영에 replica가 있었으므로 D4ds primary에 replica 생성, 동일 write 믹스(~2,900 QPS)로 유무 비교.
+
+**결과**: replica 없음 avg 26% / max 41% vs **replica 있음 avg 24% / max 34% — 차이 없음**. replica 자체는 8~15%로 WAL replay를 자기 부담.
+
+**교훈**: 물리 복제(walsender)는 primary CPU에 무해. 단, **논리복제/CDC는 다름** — 쿼리 로그의 `seq_counter`가 CDC 흔적일 수 있으므로 운영에서 `SELECT * FROM pg_replication_slots WHERE slot_type='logical';` 확인 권장.
+</details>
+
+<details>
+<summary><b>기각 7) bloat/autovacuum 단독 원인 (부분 기각 — 증폭 요인으로 재분류)</b></summary>
+
+**조건**: 1시간 최대속도 UPSERT(18.3M ops, ~6,000 QPS)로 offsets/kv 핫로우에 dead tuple 누적(14k → 470k).
+
+**결과**: autovacuum 가동 순간 동일 부하에서 CPU 35% → 62% (+25~30%p). 처리량 -19% 열화. 그러나 단독으로 100% 미도달.
+
+**교훈**: bloat/autovacuum은 주원인이 아니라 **증폭기**. 운영 offsets가 2배 bloat였던 것은 상시 UPSERT의 결과이자 CPU 여유를 갉아먹는 배경 요인.
+</details>
+
+<details>
+<summary><b>참고) PgBouncer 경유 churn/폭주 계열 — 서버는 보호되나 앱은 느려짐</b></summary>
+
+- 6432 경유 connect/close 반복 250/s: CPU 22% (churn을 PgBouncer가 흡수)
+- 6432 클라이언트 5,000개 유지 + write: 서버 backends 21~112개 고정, CPU ≤54%, mem 37~40%
+- 6432 + 480 커넥터 폭풍(§3.5): CPU 18.6%지만 연결 소요 1.4~1.9s — 싱글스레드 PgBouncer의 TLS 병목
+
+**교훈**: PgBouncer는 서버를 지키는 안전망이지 나선을 없애는 해법이 아님. 근본은 앱 풀.
+</details>
+
+---
+
+## 부록 A. 실험 매트릭스
+
+| 실험 | 조건 요약 | CPU | 판정 |
+|------|----------|----:|------|
+| run1~4 | 운영 쿼리 믹스 1x~175x, 풀 방식, 6432 | ≤49% | 기각 1 |
+| bloat driver | 최대속도 UPSERT 1h, dead tuple 누적 | +25~30%p | 증폭기 |
+| run7 | 직접 5432, 300 workers (풀 방식) | 96% | 경합 붕괴 (조건 변경) |
+| E1 reads / E3 prefix | read 믹스 / prefix 스캔 | 22% / 58~67% | 기각 2 |
+| prefix+VACUUM | 동시 실행 | 95.3% | 기각 2 (SELECT 없음) |
+| 세션 5,000 (스레드/풀) | D4ds 16GB | OOM 다운 | 기각 3 |
+| idle 4,800 (+write) | E4ds 32GB | 11~41% | 기각 4 |
+| PG13 비-SSL | 세션 폭주 | 7% (OOM) | 기각 5 |
+| **churn 480 (5432)** | **connect→INSERT→close 반복** | **99.7%** | **✅ 재현** |
+| replica A/B | 동일 write 믹스 | 24% vs 26% | 기각 6 |
+| **pool thrash** | **minIdle=0 + 버스트** | **96%** | **✅ 재현** |
+| **psycopg A/B** | **per-request vs 재사용, 워커 30** | **96% vs 70%** | **✅ 재현** |
+| **churn 480 (6432)** | 3.2와 동일, PgBouncer | 18.6% | 방어 실증 |
+| **retry spiral** | **200 tasks/s + timeout/재시도** | **99.2%** | **✅ 최종 재현 (원조건)** |
+
+## 부록 B. 재현 도구
+
+- 부하 스크립트·스키마·사용법: [cpu100-connection-churn-reproduction/](./cpu100-connection-churn-reproduction/) (README 포함)

--- a/postgresql/cpu100-connection-churn-reproduction/README.md
+++ b/postgresql/cpu100-connection-churn-reproduction/README.md
@@ -1,0 +1,99 @@
+# PostgreSQL CPU 100% 재현 및 원인 분석 — 부하 스크립트
+
+[cpu100-connection-churn-reproduction.md](../cpu100-connection-churn-reproduction.md)의 실험에 사용한 도구. 전부 Python 3.9+ / psycopg2 기반.
+
+## 공통 설정
+
+```bash
+pip install psycopg2-binary
+export PGHOST=<server>.postgres.database.azure.com
+export PGPASSWORD=<password>
+export PGUSER=pgadmin      # 기본값
+export PGDATABASE=postgres # 기본값
+```
+
+스키마: `psql -f schema.sql` (store 4테이블 + 월별 파티션 + 인덱스)
+
+## 스키마 ERD
+
+```mermaid
+erDiagram
+    store_kv {
+        text scope PK
+        text key PK
+        date part_month PK "RANGE 파티션 키 (월별)"
+        bytea value "1~2KB payload, TOAST"
+        timestamptz created_at
+        timestamptz updated_at
+        text ttl_policy
+        text ttl_policy_hash
+        timestamptz expires_at "partial index"
+    }
+    store_stream {
+        text scope PK
+        bigint seq PK
+        date part_month PK "RANGE 파티션 키 (월별)"
+        text key
+        bytea record "1KB+ payload, TOAST"
+        bigint event_ms
+        timestamptz created_at
+        text ttl_policy
+        text ttl_policy_hash
+        timestamptz expires_at "partial index"
+    }
+    store_sorted_set {
+        text scope PK
+        text member PK
+        date part_month PK "RANGE 파티션 키 (월별)"
+        double_precision score "idx (scope, score, member)"
+        timestamptz created_at
+        timestamptz updated_at
+        text ttl_policy
+        text ttl_policy_hash
+        timestamptz expires_at "partial index"
+    }
+    store_stream_offsets {
+        text scope PK "비파티션, 핫로우 UPSERT 경합 지점"
+        bigint consumed_seq
+    }
+
+    store_stream_offsets ||..o{ store_stream : "scope별 소비 오프셋 추적"
+```
+
+- 테이블 간 FK 없음 — `scope`를 논리 키로 공유하는 독립 테이블 4종 (Redis의 KV/Stream/SortedSet 유사 구조)
+- `store_kv`/`store_stream`/`store_sorted_set`: `part_month` RANGE 파티션 (테이블당 12개 월 파티션, 자식마다 인덱스 4~5개 전파)
+- `store_stream_offsets`: 비파티션 단일 테이블. `ON CONFLICT (scope) DO UPDATE` 트래픽이 집중되는 핫로우
+
+
+## 스크립트 목록
+
+| 스크립트 | 실험 (문서 §) | 용도 |
+|----------|:---:|------|
+| `retry_spiral.py` | §3.1 | **재시도 나선**: 적은 태스크율 + per-request connect + timeout/재시도 → 커넥션 눈사태 |
+| `churn_storm.py` | §3.2, §3.5 | connect→INSERT→close 반복 폭풍 (5432/6432 비교) |
+| `pool_thrash.py` | §3.3 | minIdle=0 풀 + 버스트 → 풀이 스스로 연결 개폐 반복 |
+| `replay.py` | §6 기각1 | 운영 쿼리 믹스 재현 (버스트 스케줄러 포함) |
+| `hyp.py` | §6 기각2 | read 믹스 / prefix 스캔 / 커넥션 churn(6432) 가설 테스트 |
+| `session_storm.py` | §6 기각3 | 스레드당 1세션 유지 + 주기적 write |
+| `pooled_client.py` | §6 기각3 | ThreadedConnectionPool 다인스턴스 시뮬레이션 |
+| `idle_holder.py` | §6 기각4 | 쿼리 없는 idle 세션 대량 유지 |
+| `bouncer_storm.py` | §6 참고 | PgBouncer 클라이언트 연결 대량 유지 |
+| `bloat.py` | §6 기각7 | 핫로우 UPSERT 지속으로 dead tuple/bloat 누적 |
+
+## 사용 예
+
+```bash
+# §3.1 재시도 나선 (태스크 40/s per process, 5 프로세스 권장)
+python3 retry_spiral.py 40 780 5 2   # rate duration conn_timeout retries
+
+# §3.2 churn 폭풍 (프로세스당 워커 60, 8 프로세스 권장)
+python3 churn_storm.py 60 900        # workers duration [host] [sslmode]
+
+# §3.3 pool thrashing
+python3 pool_thrash.py 10 20 0 900   # instances max_size min_idle duration
+
+# §6.1 쿼리 믹스 replay
+python3 replay.py --port 6432 --workers 120 --base-rate 3000 --burst-rate 6000 --duration 480
+```
+
+> ⚠️ 세션 수천 개를 만드는 시나리오는 대상 서버를 OOM으로 다운시킬 수 있음 (문서 §4 참고). 재현 전용 서버에서만 실행.

--- a/postgresql/cpu100-connection-churn-reproduction/bloat.py
+++ b/postgresql/cpu100-connection-churn-reproduction/bloat.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Bloat driver: sustained max-rate UPSERTs on store_stream_offsets (+hot kv keys).
+Constant client concurrency; if CPU rises over time at constant rate => bloat/autovacuum hypothesis confirmed."""
+import os, random, sys, threading, time
+from collections import Counter
+import psycopg2
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+HOST = os.environ.get("PGHOST", "localhost")
+PASS = os.environ["PGPASSWORD"]
+USER = os.environ.get("PGUSER", "pgadmin")
+DB = os.environ.get("PGDATABASE", "postgres")
+DSN = (f"host={HOST} port=6432 "
+       f"user={USER} dbname={DB} password={PASS} sslmode=require")
+
+DURATION = int(sys.argv[1]) if len(sys.argv) > 1 else 3600
+WORKERS = int(sys.argv[2]) if len(sys.argv) > 2 else 120
+
+stats = Counter(); lock = threading.Lock(); stop = threading.Event()
+
+def worker():
+    conn = None
+    while not stop.is_set():
+        try:
+            if conn is None or conn.closed:
+                conn = psycopg2.connect(DSN); conn.autocommit = True
+            with conn.cursor() as cur:
+                r = random.random()
+                if r < 0.60:
+                    # GREATEST upsert on existing rows (whole 4.7M range) -> constant row updates
+                    ns = f"ns:{random.randrange(4744457)}"
+                    cur.execute('INSERT INTO "public"."store_stream_offsets" (scope, consumed_seq) VALUES (%s,%s) '
+                                "ON CONFLICT (scope) DO UPDATE SET consumed_seq = GREATEST("
+                                '"public"."store_stream_offsets".consumed_seq, EXCLUDED.consumed_seq)',
+                                (ns, random.randrange(10**12)))
+                    k = 'off_greatest'
+                elif r < 0.85:
+                    # increment upsert on HOT scopes -> same-row contention like production
+                    ns = f"ns:{random.randrange(50)}"
+                    cur.execute('INSERT INTO "public"."store_stream_offsets" (scope, consumed_seq) VALUES (%s,%s) '
+                                "ON CONFLICT (scope) DO UPDATE SET consumed_seq = "
+                                '"public"."store_stream_offsets".consumed_seq + %s RETURNING consumed_seq',
+                                (ns, 1, 1))
+                    k = 'off_incr_hot'
+                else:
+                    # kv hot-key upsert (1.8KB payload rewrite -> TOAST+index churn)
+                    ns = f"ns:{random.randrange(3)}"
+                    cur.execute('INSERT INTO "public"."store_kv" (scope, key, value) VALUES (%s,%s,%s) '
+                                "ON CONFLICT (scope, key, part_month) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()",
+                                (ns, f"hotkey:{random.randrange(5000)}", psycopg2.Binary(os.urandom(1800))))
+                    k = 'kv_upsert_hot'
+            with lock: stats[k] += 1
+        except Exception as e:
+            with lock: stats['err:' + type(e).__name__] += 1
+            time.sleep(0.5); conn = None
+
+t0 = time.time()
+threads = [threading.Thread(target=worker, daemon=True) for _ in range(WORKERS)]
+for t in threads: t.start()
+last = 0
+try:
+    while time.time() - t0 < DURATION:
+        time.sleep(30)
+        with lock: cur = dict(stats)
+        tot = sum(v for k, v in cur.items() if not k.startswith('err'))
+        print(f"[{int(time.time()-t0):5d}s] qps={(tot-last)/30:7.1f} total={tot:9d} {cur}", flush=True)
+        last = tot
+finally:
+    stop.set()
+    print("BLOAT_DRIVER_DONE", dict(stats), flush=True)

--- a/postgresql/cpu100-connection-churn-reproduction/bloat.py
+++ b/postgresql/cpu100-connection-churn-reproduction/bloat.py
@@ -52,6 +52,9 @@ def worker():
             with lock: stats[k] += 1
         except Exception as e:
             with lock: stats['err:' + type(e).__name__] += 1
+            if conn is not None:
+                try: conn.close()
+                except Exception: pass
             time.sleep(0.5); conn = None
 
 t0 = time.time()

--- a/postgresql/cpu100-connection-churn-reproduction/bouncer_storm.py
+++ b/postgresql/cpu100-connection-churn-reproduction/bouncer_storm.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""PgBouncer client-connection storm: hold N idle client conns on :6432
+(cheap for postgres backends - pgbouncer multiplexes to small server pool)
+while a subset actively writes. Tests single-threaded pgbouncer as CPU bottleneck.
+Usage: bouncer_storm.py <idle_conns> <duration_s> [ramp_s]
+"""
+import os, sys, time
+import psycopg2
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+HOST = os.environ.get("PGHOST", "localhost")
+PASS = os.environ["PGPASSWORD"]
+USER = os.environ.get("PGUSER", "pgadmin")
+DB = os.environ.get("PGDATABASE", "postgres")
+DSN = (f"host={HOST} port=6432 "
+       f"user={USER} dbname={DB} password={PASS} sslmode=require connect_timeout=15")
+
+N = int(sys.argv[1]); DURATION = int(sys.argv[2])
+RAMP = float(sys.argv[3]) if len(sys.argv) > 3 else 180.0
+
+conns = []
+t0 = time.time(); errs = 0
+for i in range(N):
+    try:
+        conns.append(psycopg2.connect(DSN))
+    except Exception as e:
+        errs += 1
+        if errs % 50 == 1: print(f"[{int(time.time()-t0)}s] err#{errs}: {type(e).__name__}: {e}", flush=True)
+        time.sleep(0.5)
+    if i % 200 == 0: print(f"[{int(time.time()-t0)}s] {len(conns)}/{N} errs={errs}", flush=True)
+    time.sleep(max(0.0, RAMP/N))
+print(f"HOLDING {len(conns)} pgbouncer client conns (errs={errs})", flush=True)
+end = t0 + DURATION
+while time.time() < end:
+    time.sleep(15)
+    alive = [c for c in conns if c.closed == 0]
+    if len(alive) != len(conns):
+        print(f"[{int(time.time()-t0)}s] alive={len(alive)}", flush=True)
+        conns = alive
+print(f"BOUNCER_DONE held={len(conns)}", flush=True)

--- a/postgresql/cpu100-connection-churn-reproduction/churn_storm.py
+++ b/postgresql/cpu100-connection-churn-reproduction/churn_storm.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Direct-5432 connection churn storm: each worker loops
+connect(TCP+TLS+fork backend) -> 1 INSERT -> close.
+This is what a client WITHOUT pooling does under load.
+Usage: churn_storm.py <workers> <duration_s> [host] [ssl]
+"""
+import os, random, sys, threading, time
+from collections import Counter
+import psycopg2
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+PASS = os.environ["PGPASSWORD"]
+USER = os.environ.get("PGUSER", "pgadmin")
+DB = os.environ.get("PGDATABASE", "postgres")
+HOST = sys.argv[3] if len(sys.argv) > 3 else os.environ.get("PGHOST", "localhost")
+SSL = sys.argv[4] if len(sys.argv) > 4 else "require"
+DSN = (f"host={HOST} port=5432 user={USER} dbname={DB} "
+       f"password={PASS} sslmode={SSL} connect_timeout=15")
+
+WORKERS = int(sys.argv[1]); DURATION = int(sys.argv[2])
+HOT_NS = ["ns:0", "ns:1", "ns:2"]
+
+stats = Counter(); lock = threading.Lock(); stop = threading.Event()
+
+def worker():
+    while not stop.is_set():
+        try:
+            t0 = time.time()
+            conn = psycopg2.connect(DSN)
+            conn.autocommit = True
+            dt_conn = time.time() - t0
+            with conn.cursor() as cur:
+                ns = random.choice(HOT_NS) if random.random() < 0.55 else f"ns:{3+random.randrange(100000)}"
+                cur.execute('INSERT INTO "public"."store_stream_offsets" (scope, consumed_seq) VALUES (%s,%s) '
+                            'ON CONFLICT (scope) DO UPDATE SET consumed_seq = GREATEST("public"."store_stream_offsets".consumed_seq, EXCLUDED.consumed_seq)',
+                            (ns, random.randrange(10**8)))
+            conn.close()
+            with lock:
+                stats['cycles'] += 1
+                stats['conn_ms_sum'] += int(dt_conn * 1000)
+        except Exception as e:
+            with lock: stats['err:' + type(e).__name__] += 1
+            time.sleep(0.5)
+
+threading.stack_size(512 * 1024)
+t0 = time.time()
+threads = [threading.Thread(target=worker, daemon=True) for _ in range(WORKERS)]
+for i, t in enumerate(threads):
+    t.start()
+    if i % 50 == 0: time.sleep(0.5)  # gentle ramp
+
+last = 0
+try:
+    while time.time() - t0 < DURATION:
+        time.sleep(20)
+        with lock: cur = dict(stats)
+        c = cur.get('cycles', 0)
+        rate = (c - last) / 20
+        avg_ms = cur.get('conn_ms_sum', 0) // max(c, 1)
+        errs = {k: v for k, v in cur.items() if k.startswith('err')}
+        print(f"[{int(time.time()-t0):5d}s] conn_rate={rate:7.1f}/s avg_conn_ms={avg_ms} total={c} errs={errs}", flush=True)
+        last = c
+finally:
+    stop.set()
+    print("CHURN_DONE", dict(stats), flush=True)

--- a/postgresql/cpu100-connection-churn-reproduction/hyp.py
+++ b/postgresql/cpu100-connection-churn-reproduction/hyp.py
@@ -104,6 +104,9 @@ def run_persistent(ops, write_ratio=0.0):
             with lock: stats[k] += 1
         except Exception as e:
             with lock: stats['err:'+type(e).__name__] += 1
+            if conn is not None:
+                try: conn.close()
+                except Exception: pass
             time.sleep(0.5); conn = None
 
 def run_churn():

--- a/postgresql/cpu100-connection-churn-reproduction/hyp.py
+++ b/postgresql/cpu100-connection-churn-reproduction/hyp.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""E1/E2/E3 hypothesis tester. All via PgBouncer 6432 (production-faithful path).
+Modes:
+  reads   - E1: session-store read mix (kv point GET, sorted_set range, log tail) + write mix at recorded ratio
+  churn   - E2: short-lived connect/one-query/disconnect loops (TLS handshake cost)
+  prefix  - E3: scope LIKE 'prefix%' scans (text_pattern_ops index usage evidence)
+"""
+import os, random, string, sys, threading, time
+from collections import Counter
+import psycopg2
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+HOST = os.environ.get("PGHOST", "localhost")
+PASS = os.environ["PGPASSWORD"]
+USER = os.environ.get("PGUSER", "pgadmin")
+DB = os.environ.get("PGDATABASE", "postgres")
+def dsn(port=6432):
+    return (f"host={HOST} port={port} "
+            f"user={USER} dbname={DB} password={PASS} sslmode=require")
+
+MODE = sys.argv[1]
+DURATION = int(sys.argv[2]) if len(sys.argv) > 2 else 480
+WORKERS = int(sys.argv[3]) if len(sys.argv) > 3 else 60
+
+stats = Counter(); lock = threading.Lock(); stop = threading.Event()
+HOT_NS = ["ns:0", "ns:1", "ns:2"]
+
+def pick_ns():
+    return random.choice(HOT_NS) if random.random() < 0.55 else f"ns:{3+random.randrange(100000)}"
+
+# --- E1 read ops (session-store access patterns implied by the schema) ---
+def r_kv_get(cur):
+    # point lookup on hot key -> TOAST detoast of 1.8KB value
+    cur.execute('SELECT value FROM "public"."store_kv" WHERE scope=%s AND key=%s',
+                (pick_ns(), f"hotkey:{random.randrange(5000)}"))
+    cur.fetchall()
+
+def r_kv_get_month(cur):
+    # point lookup with part_month (partition-pruned)
+    cur.execute('SELECT value FROM "public"."store_kv" WHERE scope=%s AND key=%s AND part_month=%s',
+                (pick_ns(), f"k:2026-07:{random.randrange(9000000)}", '2026-07-01'))
+    cur.fetchall()
+
+def r_ss_range(cur):
+    # ZRANGEBYSCORE equivalent -> uses (scope, score, member) index
+    lo = random.random() * 900000
+    cur.execute('SELECT member, score FROM "public"."store_sorted_set" '
+                'WHERE scope=%s AND score BETWEEN %s AND %s ORDER BY score LIMIT 100',
+                (pick_ns(), lo, lo + 10000))
+    cur.fetchall()
+
+def r_log_tail(cur):
+    # stream tail read
+    cur.execute('SELECT seq, record FROM "public"."store_stream" '
+                'WHERE scope=%s AND part_month=%s ORDER BY seq DESC LIMIT 50',
+                (pick_ns(), '2026-07-01'))
+    cur.fetchall()
+
+def r_offsets_get(cur):
+    cur.execute('SELECT consumed_seq FROM "public"."store_stream_offsets" WHERE scope=%s',
+                (f"ns:{random.randrange(4744457)}",))
+    cur.fetchall()
+
+READ_OPS = [(30,'kv_get',r_kv_get),(15,'kv_get_month',r_kv_get_month),
+            (25,'ss_range',r_ss_range),(20,'log_tail',r_log_tail),(10,'offsets_get',r_offsets_get)]
+
+def w_kv_upsert(cur):
+    cur.execute('INSERT INTO "public"."store_kv" (scope, key, value) VALUES (%s,%s,%s) '
+                "ON CONFLICT (scope, key, part_month) DO UPDATE SET value=EXCLUDED.value, updated_at=NOW()",
+                (pick_ns(), f"hotkey:{random.randrange(5000)}", psycopg2.Binary(os.urandom(1800))))
+
+# --- E3 prefix ops ---
+def p_kv_prefix(cur):
+    cur.execute('SELECT scope, key FROM "public"."store_kv" '
+                "WHERE scope LIKE %s LIMIT 200", (f"ns:{random.randrange(100)}%",))
+    cur.fetchall()
+
+def p_ss_prefix_del_sim(cur):
+    # scope-prefix listing on sorted_set (cleanup scan pattern)
+    cur.execute('SELECT scope, member FROM "public"."store_sorted_set" '
+                "WHERE scope LIKE %s LIMIT 200", (f"ns:{random.randrange(100)}%",))
+    cur.fetchall()
+
+def p_offsets_prefix(cur):
+    cur.execute('SELECT scope, consumed_seq FROM "public"."store_stream_offsets" '
+                "WHERE scope LIKE %s LIMIT 500", (f"ns:{random.randrange(1000)}%",))
+    cur.fetchall()
+
+PREFIX_OPS = [(40,'kv_prefix',p_kv_prefix),(30,'ss_prefix',p_ss_prefix_del_sim),(30,'off_prefix',p_offsets_prefix)]
+
+def run_persistent(ops, write_ratio=0.0):
+    weights = [w for w,_,_ in ops]
+    conn = None
+    while not stop.is_set():
+        try:
+            if conn is None or conn.closed:
+                conn = psycopg2.connect(dsn()); conn.autocommit = True
+            with conn.cursor() as cur:
+                if write_ratio and random.random() < write_ratio:
+                    w_kv_upsert(cur); k = 'kv_upsert'
+                else:
+                    _, k, fn = random.choices(ops, weights=weights)[0]
+                    fn(cur)
+            with lock: stats[k] += 1
+        except Exception as e:
+            with lock: stats['err:'+type(e).__name__] += 1
+            time.sleep(0.5); conn = None
+
+def run_churn():
+    # connect -> 1 light query -> disconnect (TLS handshake each time)
+    while not stop.is_set():
+        try:
+            conn = psycopg2.connect(dsn()); conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute('SELECT consumed_seq FROM "public"."store_stream_offsets" WHERE scope=%s',
+                            (f"ns:{random.randrange(4744457)}",))
+                cur.fetchall()
+            conn.close()
+            with lock: stats['churn_cycle'] += 1
+        except Exception as e:
+            with lock: stats['err:'+type(e).__name__] += 1
+            time.sleep(0.2)
+
+target = {'reads': lambda: run_persistent(READ_OPS, write_ratio=0.3),
+          'prefix': lambda: run_persistent(PREFIX_OPS),
+          'churn': run_churn}[MODE]
+
+t0 = time.time()
+threads = [threading.Thread(target=target, daemon=True) for _ in range(WORKERS)]
+for t in threads: t.start()
+last = 0
+try:
+    while time.time() - t0 < DURATION:
+        time.sleep(30)
+        with lock: cur = dict(stats)
+        tot = sum(v for k,v in cur.items() if not k.startswith('err'))
+        print(f"[{int(time.time()-t0):5d}s] qps={(tot-last)/30:7.1f} {cur}", flush=True)
+        last = tot
+finally:
+    stop.set()
+    print(f"{MODE.upper()}_DONE", dict(stats), flush=True)

--- a/postgresql/cpu100-connection-churn-reproduction/idle_holder.py
+++ b/postgresql/cpu100-connection-churn-reproduction/idle_holder.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Idle session holder: opens N connections and holds them WITHOUT running queries.
+No threads - just sockets kept open. Simulates leaked/oversized pool connections.
+Usage: idle_holder.py <num_conns> <duration_s> [ramp_s]
+"""
+import os, sys, time
+import psycopg2
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+HOST = os.environ.get("PGHOST", "localhost")
+PASS = os.environ["PGPASSWORD"]
+USER = os.environ.get("PGUSER", "pgadmin")
+DB = os.environ.get("PGDATABASE", "postgres")
+DSN = (f"host={HOST} port=5432 "
+       f"user={USER} dbname={DB} password={PASS} sslmode=require connect_timeout=15")
+
+N = int(sys.argv[1])
+DURATION = int(sys.argv[2])
+RAMP = float(sys.argv[3]) if len(sys.argv) > 3 else 120.0
+
+conns = []
+t0 = time.time()
+errs = 0
+for i in range(N):
+    try:
+        c = psycopg2.connect(DSN)
+        conns.append(c)
+    except Exception as e:
+        errs += 1
+        if errs % 50 == 1:
+            print(f"[{int(time.time()-t0)}s] connect error #{errs}: {type(e).__name__}", flush=True)
+        time.sleep(1)
+    if i % 100 == 0:
+        print(f"[{int(time.time()-t0)}s] opened {len(conns)}/{N} (errs={errs})", flush=True)
+    time.sleep(max(0.0, RAMP/N))
+
+print(f"HOLDING {len(conns)} idle conns (errs={errs})", flush=True)
+end = t0 + DURATION
+while time.time() < end:
+    time.sleep(10)
+    # prune dead sockets
+    alive = [c for c in conns if c.closed == 0]
+    if len(alive) != len(conns):
+        print(f"[{int(time.time()-t0)}s] alive={len(alive)}", flush=True)
+        conns = alive
+print(f"IDLE_DONE held={len(conns)}", flush=True)
+for c in conns:
+    try: c.close()
+    except Exception: pass

--- a/postgresql/cpu100-connection-churn-reproduction/pool_thrash.py
+++ b/postgresql/cpu100-connection-churn-reproduction/pool_thrash.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Pool thrashing simulation: pools EXIST but still churn connections.
+Mimics HikariCP-style config gone wrong: minIdle=0 (or low), short idleTimeout,
+bursty traffic. Every burst the pool must open fresh connections (TLS+fork),
+every quiet period it evicts them.
+
+Each "instance" = pool with max_size conns. Cycle:
+  burst phase (burst_s): all workers demand conns -> pool opens up to max -> writes
+  quiet phase: idleTimeout expires -> pool closes idle conns down to min_idle
+Usage: pool_thrash.py <instances> <max_size> <min_idle> <duration_s>
+"""
+import os, random, sys, threading, time
+from collections import Counter
+import psycopg2
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+HOST = os.environ.get("PGHOST", "localhost")
+PASS = os.environ["PGPASSWORD"]
+USER = os.environ.get("PGUSER", "pgadmin")
+DB = os.environ.get("PGDATABASE", "postgres")
+DSN = (f"host={HOST} port=5432 "
+       f"user={USER} dbname={DB} password={PASS} sslmode=require connect_timeout=15")
+
+INSTANCES = int(sys.argv[1]); MAX_SIZE = int(sys.argv[2])
+MIN_IDLE = int(sys.argv[3]); DURATION = int(sys.argv[4])
+BURST_S = 4.0; PERIOD_S = 12.0   # §6.2 burst shape
+
+HOT_NS = ["ns:0", "ns:1", "ns:2"]
+def pick_ns():
+    return random.choice(HOT_NS) if random.random() < 0.55 else f"ns:{3+random.randrange(100000)}"
+
+stats = Counter(); lock = threading.Lock(); stop = threading.Event()
+
+class ThrashPool:
+    """min_idle..max_size pool with aggressive idle eviction (the misconfig)."""
+    def __init__(self):
+        self.idle = []; self.n_open = 0; self.lk = threading.Lock()
+    def get(self):
+        with self.lk:
+            if self.idle:
+                return self.idle.pop()
+            if self.n_open >= MAX_SIZE:
+                return None
+            self.n_open += 1
+        try:
+            c = psycopg2.connect(DSN); c.autocommit = True
+            with lock: stats['conn_opened'] += 1
+            return c
+        except Exception as e:
+            with self.lk: self.n_open -= 1
+            with lock: stats['err:'+type(e).__name__] += 1
+            return None
+    def put(self, c):
+        with self.lk: self.idle.append(c)
+    def evict(self):
+        with self.lk:
+            keep = self.idle[:MIN_IDLE]; drop = self.idle[MIN_IDLE:]
+            self.idle = keep; self.n_open -= len(drop)
+        for c in drop:
+            try: c.close()
+            except Exception: pass
+        if drop:
+            with lock: stats['conn_evicted'] += len(drop)
+
+def one_write(cur):
+    cur.execute('INSERT INTO "public"."store_stream_offsets" (scope, consumed_seq) VALUES (%s,%s) '
+                'ON CONFLICT (scope) DO UPDATE SET consumed_seq = GREATEST("public"."store_stream_offsets".consumed_seq, EXCLUDED.consumed_seq)',
+                (pick_ns(), random.randrange(10**8)))
+
+def instance(idx):
+    p = ThrashPool()
+    t0 = time.time()
+    while not stop.is_set():
+        phase = (time.time() - t0) % PERIOD_S
+        if phase < BURST_S:
+            # burst: hammer with MAX_SIZE parallel demands
+            def burst_worker():
+                c = p.get()
+                if c is None:
+                    with lock: stats['pool_exhausted'] += 1
+                    return
+                try:
+                    with c.cursor() as cur:
+                        for _ in range(random.randrange(2, 6)):
+                            one_write(cur)
+                    with lock: stats['writes'] += 1
+                    p.put(c)
+                except Exception as e:
+                    with lock: stats['err:'+type(e).__name__] += 1
+                    try: c.close()
+                    except Exception: pass
+                    with p.lk: p.n_open -= 1
+            ts = [threading.Thread(target=burst_worker, daemon=True) for _ in range(MAX_SIZE)]
+            for t in ts: t.start()
+            for t in ts: t.join(timeout=8)
+            time.sleep(0.3)
+        else:
+            # quiet: idleTimeout fires -> evict down to min_idle
+            p.evict()
+            time.sleep(0.5)
+
+threading.stack_size(512*1024)
+t0 = time.time()
+insts = [threading.Thread(target=instance, args=(i,), daemon=True) for i in range(INSTANCES)]
+for i, t in enumerate(insts):
+    t.start(); time.sleep(0.15)  # stagger phases across instances
+
+last_open = 0
+try:
+    while time.time() - t0 < DURATION:
+        time.sleep(20)
+        with lock: cur = dict(stats)
+        opened = cur.get('conn_opened', 0)
+        rate = (opened - last_open) / 20
+        print(f"[{int(time.time()-t0):5d}s] conn_open_rate={rate:6.1f}/s opened={opened} evicted={cur.get('conn_evicted',0)} "
+              f"writes={cur.get('writes',0)} exhausted={cur.get('pool_exhausted',0)} "
+              f"errs={ {k:v for k,v in cur.items() if k.startswith('err')} }", flush=True)
+        last_open = opened
+finally:
+    stop.set()
+    print("THRASH_DONE", dict(stats), flush=True)

--- a/postgresql/cpu100-connection-churn-reproduction/pooled_client.py
+++ b/postgresql/cpu100-connection-churn-reproduction/pooled_client.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Pooled-client reproduction: N app instances x M pool size (psycopg2 ThreadedConnectionPool).
+Simulates production topology where many app replicas each hold a persistent pool,
+totaling ~5000 server sessions. Write-only mix per issue #41 §6.1.
+
+Usage: pooled_client.py <instances> <pool_size> <duration_s> <total_qps>
+Each "instance" = one ThreadedConnectionPool(minconn=pool_size, maxconn=pool_size)
+with pool_size worker threads doing getconn -> write -> putconn.
+"""
+import os, random, sys, threading, time
+from collections import Counter
+import psycopg2
+from psycopg2 import pool as pgpool
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+HOST = os.environ.get("PGHOST", "localhost")
+PASS = os.environ["PGPASSWORD"]
+USER = os.environ.get("PGUSER", "pgadmin")
+DB = os.environ.get("PGDATABASE", "postgres")
+DSN = (f"host={HOST} port=5432 "
+       f"user={USER} dbname={DB} password={PASS} sslmode=require connect_timeout=20")
+
+INSTANCES = int(sys.argv[1]) if len(sys.argv) > 1 else 10
+POOL_SIZE = int(sys.argv[2]) if len(sys.argv) > 2 else 40
+DURATION = int(sys.argv[3]) if len(sys.argv) > 3 else 900
+TOTAL_QPS = float(sys.argv[4]) if len(sys.argv) > 4 else 1000.0
+
+HOT_NS = ["ns:0", "ns:1", "ns:2"]
+def pick_ns():
+    return random.choice(HOT_NS) if random.random() < 0.55 else f"ns:{3+random.randrange(100000)}"
+
+stats = Counter(); lock = threading.Lock(); stop = threading.Event()
+pools_ready = [0]
+
+def one_write(cur, st):
+    r = random.random()
+    if r < 0.23:
+        st['seq'] = st.get('seq', random.randrange(10**9)) + 1
+        cur.execute('INSERT INTO "public"."store_stream" (scope, seq, key, record, event_ms, part_month) VALUES (%s,%s,%s,%s,%s,%s)',
+                    (pick_ns(), st['seq']*1000+random.randrange(1000), 'k', psycopg2.Binary(os.urandom(1200)),
+                     int(time.time()*1000), '2026-07-01')); return 'log_ins'
+    elif r < 0.43:
+        cur.execute('INSERT INTO "public"."store_kv" (scope, key, value) VALUES (%s,%s,%s)',
+                    (pick_ns(), f"pk:{random.randrange(10**9)}", psycopg2.Binary(os.urandom(1800)))); return 'kv_ins'
+    elif r < 0.61:
+        cur.execute('INSERT INTO "public"."store_stream_offsets" (scope, consumed_seq) VALUES (%s,%s) '
+                    'ON CONFLICT (scope) DO UPDATE SET consumed_seq = GREATEST("public"."store_stream_offsets".consumed_seq, EXCLUDED.consumed_seq)',
+                    (pick_ns(), random.randrange(10**8))); return 'off_ups'
+    elif r < 0.78:
+        cur.execute('INSERT INTO "public"."store_kv" (scope, key, value) VALUES (%s,%s,%s) '
+                    'ON CONFLICT (scope, key, part_month) DO UPDATE SET value=EXCLUDED.value, updated_at=NOW()',
+                    (pick_ns(), f"hotkey:{random.randrange(5000)}", psycopg2.Binary(os.urandom(1800)))); return 'kv_ups'
+    elif r < 0.90:
+        cur.execute('INSERT INTO "public"."store_sorted_set" (scope, member, score) VALUES (%s,%s,%s) ON CONFLICT DO NOTHING',
+                    (pick_ns(), f"pm:{random.randrange(10**9)}", random.random()*1e6)); return 'ss_ins'
+    else:
+        cur.execute('INSERT INTO "public"."store_sorted_set" (scope, member, score) VALUES (%s,%s,%s) '
+                    'ON CONFLICT (scope, member, part_month) DO UPDATE SET score=EXCLUDED.score, updated_at=NOW()',
+                    (pick_ns(), f"hotmember:{random.randrange(5000)}", random.random()*1e6)); return 'ss_ups'
+
+TOTAL_WORKERS = INSTANCES * POOL_SIZE
+PER_WORKER_INTERVAL = TOTAL_WORKERS / TOTAL_QPS  # seconds between ops per worker
+
+def worker(p):
+    st = {}
+    while not stop.is_set():
+        time.sleep(random.expovariate(1.0 / PER_WORKER_INTERVAL))
+        if stop.is_set(): break
+        conn = None
+        try:
+            conn = p.getconn()
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                k = one_write(cur, st)
+            with lock: stats[k] += 1
+        except Exception as e:
+            with lock: stats['err:'+type(e).__name__] += 1
+            time.sleep(1)
+        finally:
+            if conn is not None:
+                try: p.putconn(conn)
+                except Exception: pass
+
+def instance(idx, ramp_delay):
+    time.sleep(ramp_delay)
+    try:
+        # minconn=POOL_SIZE: pools hold all connections persistently (typical prod config)
+        p = pgpool.ThreadedConnectionPool(POOL_SIZE, POOL_SIZE, DSN)
+        with lock: pools_ready[0] += 1
+    except Exception as e:
+        with lock: stats['err:pool_init:'+type(e).__name__] += 1
+        return
+    ts = [threading.Thread(target=worker, args=(p,), daemon=True) for _ in range(POOL_SIZE)]
+    for t in ts: t.start()
+    while not stop.is_set(): time.sleep(1)
+
+threading.stack_size(512*1024)
+t0 = time.time()
+RAMP = 120.0
+insts = [threading.Thread(target=instance, args=(i, RAMP*i/INSTANCES), daemon=True) for i in range(INSTANCES)]
+for t in insts: t.start()
+
+last = 0
+try:
+    while time.time() - t0 < DURATION:
+        time.sleep(30)
+        with lock: cur = dict(stats); pr = pools_ready[0]
+        tot = sum(v for k,v in cur.items() if not k.startswith('err'))
+        errs = {k:v for k,v in cur.items() if k.startswith('err')}
+        print(f"[{int(time.time()-t0):5d}s] pools={pr}/{INSTANCES} (~{pr*POOL_SIZE} conns) qps={(tot-last)/30:7.1f} total={tot:8d} errs={errs}", flush=True)
+        last = tot
+finally:
+    stop.set()
+    print("POOLED_DONE", dict(stats), flush=True)

--- a/postgresql/cpu100-connection-churn-reproduction/replay.py
+++ b/postgresql/cpu100-connection-churn-reproduction/replay.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Issue #41 traffic replay: query mix per §6.1, bursts per §6.2, via PgBouncer :6432."""
+import argparse, os, random, signal, string, sys, threading, time
+from collections import Counter
+
+import psycopg2
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+HOST = os.environ.get("PGHOST", "localhost")
+PASS = os.environ["PGPASSWORD"]
+USER = os.environ.get("PGUSER", "pgadmin")
+DB = os.environ.get("PGDATABASE", "postgres")
+
+def dsn(port):
+    return (f"host={HOST} port={port} "
+            f"user={USER} dbname={DB} password={PASS} sslmode=require")
+
+HOT_NS = ["ns:0", "ns:1", "ns:2"]          # hot scopes (40~70% of traffic)
+BUCKET = "2026-07-01"                       # current month partition
+
+def pick_ns():
+    # 55% hot (1-3 scopes), 45% long tail
+    if random.random() < 0.55:
+        return random.choice(HOT_NS)
+    return f"ns:{3 + random.randrange(100000)}"
+
+def rand_key(n=24):
+    return "".join(random.choices(string.ascii_lowercase + string.digits, k=n))
+
+def payload(size):
+    return psycopg2.Binary(os.urandom(size))
+
+# ---- operations (weights = ops/hour from §6.1) ----
+def op_log_insert(cur, st):
+    ns = pick_ns()
+    seq = st["seq"] = st.get("seq", random.randrange(10**9)) + 1
+    cur.execute('INSERT INTO "public"."store_stream" (scope, seq, key, record, event_ms, part_month) '
+                "VALUES (%s,%s,%s,%s,%s,%s)",
+                (ns, seq * 1000 + random.randrange(1000), rand_key(), payload(1200),
+                 int(time.time()*1000), BUCKET))
+
+def op_kv_insert(cur, st):
+    cur.execute('INSERT INTO "public"."store_kv" (scope, key, value) VALUES (%s,%s,%s)',
+                (pick_ns(), rand_key(), payload(1800)))
+
+def op_offsets_upsert(cur, st):
+    cur.execute('INSERT INTO "public"."store_stream_offsets" (scope, consumed_seq) VALUES (%s,%s) '
+                "ON CONFLICT (scope) DO UPDATE SET consumed_seq = GREATEST("
+                '"public"."store_stream_offsets".consumed_seq, EXCLUDED.consumed_seq)',
+                (pick_ns(), random.randrange(10**8)))
+
+def op_kv_upsert(cur, st):
+    key = f"hotkey:{random.randrange(5000)}"
+    cur.execute('INSERT INTO "public"."store_kv" (scope, key, value) VALUES (%s,%s,%s) '
+                "ON CONFLICT (scope, key, part_month) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()",
+                (pick_ns(), key, payload(1800)))
+
+def op_ss_insert(cur, st):
+    cur.execute('INSERT INTO "public"."store_sorted_set" (scope, member, score) VALUES (%s,%s,%s) '
+                "ON CONFLICT (scope, member, part_month) DO NOTHING",
+                (pick_ns(), rand_key(), random.random()*1e6))
+
+def op_ss_upsert(cur, st):
+    member = f"hotmember:{random.randrange(5000)}"
+    cur.execute('INSERT INTO "public"."store_sorted_set" (scope, member, score) VALUES (%s,%s,%s) '
+                "ON CONFLICT (scope, member, part_month) DO UPDATE SET score = EXCLUDED.score, updated_at = NOW()",
+                (pick_ns(), member, random.random()*1e6))
+
+def op_ss_delete(cur, st):
+    cur.execute('DELETE FROM "public"."store_sorted_set" WHERE scope = %s AND member = %s',
+                (pick_ns(), f"hotmember:{random.randrange(5000)}"))
+
+def op_seq_counter(cur, st):
+    cur.execute("insert into public.seq_counter (id, update_time) select %s, now() "
+                "on conflict on constraint seq_counter_pk do update set id = public.seq_counter.id+%s, update_time=now()",
+                (1, 1))
+
+OPS = [
+    (18220, "log_insert",     op_log_insert),
+    (15519, "kv_insert",      op_kv_insert),
+    (14371, "offsets_upsert", op_offsets_upsert),
+    (13792, "kv_upsert",      op_kv_upsert),
+    (9264,  "ss_insert",      op_ss_insert),
+    (6040,  "ss_upsert",      op_ss_upsert),
+    (2180,  "ss_delete",      op_ss_delete),
+    (486,   "seq_counter",       op_seq_counter),
+]
+WEIGHTS = [w for w, _, _ in OPS]
+
+stats = Counter()
+errors = Counter()
+lock = threading.Lock()
+stop = threading.Event()
+
+def worker(port, rate_fn):
+    st = {}
+    conn = None
+    while not stop.is_set():
+        try:
+            if conn is None or conn.closed:
+                conn = psycopg2.connect(dsn(port))
+                conn.autocommit = True
+            target = rate_fn()          # per-worker ops/sec right now
+            t0 = time.time()
+            n = 0
+            while time.time() - t0 < 1.0 and not stop.is_set():
+                if n >= target:
+                    time.sleep(0.02); continue
+                w, name, fn = random.choices(OPS, weights=WEIGHTS)[0]
+                try:
+                    with conn.cursor() as cur:
+                        fn(cur, st)
+                    with lock: stats[name] += 1
+                except psycopg2.Error as e:
+                    with lock: errors[type(e).__name__] += 1
+                    if conn.closed: conn = None; break
+                n += 1
+        except Exception as e:
+            with lock: errors["conn:" + type(e).__name__] += 1
+            time.sleep(1); conn = None
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=6432)
+    ap.add_argument("--workers", type=int, default=24)
+    ap.add_argument("--base-rate", type=float, default=150, help="total ops/s baseline")
+    ap.add_argument("--burst-rate", type=float, default=600, help="total ops/s during burst")
+    ap.add_argument("--burst-secs", type=float, default=4)
+    ap.add_argument("--burst-period", type=float, default=12)
+    ap.add_argument("--duration", type=int, default=900)
+    a = ap.parse_args()
+
+    t_start = time.time()
+    def rate_fn():
+        phase = (time.time() - t_start) % a.burst_period
+        total = a.burst_rate if phase < a.burst_secs else a.base_rate
+        return total / a.workers
+
+    threads = [threading.Thread(target=worker, args=(a.port, rate_fn), daemon=True)
+               for _ in range(a.workers)]
+    for t in threads: t.start()
+
+    last = Counter()
+    try:
+        while time.time() - t_start < a.duration:
+            time.sleep(10)
+            with lock:
+                cur = Counter(stats); errs = dict(errors)
+            delta = sum(cur.values()) - sum(last.values())
+            print(f"[{int(time.time()-t_start):4d}s] qps={delta/10:6.1f} total={sum(cur.values()):8d} "
+                  f"mix={dict(cur.most_common(4))} errs={errs}", flush=True)
+            last = cur
+    finally:
+        stop.set()
+        for t in threads: t.join(timeout=3)
+        print("FINAL:", dict(stats), "ERRORS:", dict(errors), flush=True)
+
+if __name__ == "__main__":
+    main()

--- a/postgresql/cpu100-connection-churn-reproduction/replay.py
+++ b/postgresql/cpu100-connection-churn-reproduction/replay.py
@@ -117,6 +117,9 @@ def worker(port, rate_fn):
                 n += 1
         except Exception as e:
             with lock: errors["conn:" + type(e).__name__] += 1
+            if conn is not None:
+                try: conn.close()
+                except Exception: pass
             time.sleep(1); conn = None
 
 def main():

--- a/postgresql/cpu100-connection-churn-reproduction/retry_spiral.py
+++ b/postgresql/cpu100-connection-churn-reproduction/retry_spiral.py
@@ -71,6 +71,7 @@ t0 = time.time()
 gen_interval = 1.0 / RATE
 next_t = time.time()
 last_ok = 0
+next_report = t0 + 20
 
 while time.time() - t0 < DURATION and not stop.is_set():
     now = time.time()
@@ -83,8 +84,9 @@ while time.time() - t0 < DURATION and not stop.is_set():
             with lock: stats['client_saturated'] += 1
     else:
         time.sleep(min(0.005, next_t - now))
-    # periodic report
-    if int(now - t0) % 20 == 0 and now - t0 - int(now - t0) < 0.01:
+    # periodic report (monotonic schedule)
+    if now >= next_report:
+        next_report += 20
         with lock:
             c = dict(stats); ifl = inflight[0]
         ok = c.get('insert_ok', 0)
@@ -93,7 +95,6 @@ while time.time() - t0 < DURATION and not stop.is_set():
               f"ok={ok} retries={c.get('conn_fail_retry',0)} gaveup={c.get('task_gave_up',0)} "
               f"client_sat={c.get('client_saturated',0)} avg_conn_ms={avg}", flush=True)
         last_ok = ok
-        time.sleep(0.02)
 
 stop.set()
 print("SPIRAL_DONE", dict(stats), "inflight_final", inflight[0], flush=True)

--- a/postgresql/cpu100-connection-churn-reproduction/retry_spiral.py
+++ b/postgresql/cpu100-connection-churn-reproduction/retry_spiral.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Retry-spiral reproduction: modest fixed task rate -> connection avalanche.
+
+Each task (e.g. one app request needing 1 INSERT):
+  connect (timeout T) -> INSERT -> close
+  on connect timeout/failure: retry up to R times (typical app/driver behavior)
+
+Offered load is SMALL (default 80 tasks/s = issue burst rate) but in-flight
+connections = rate x latency, so as connect latency degrades, concurrent
+connection attempts snowball. Completed inserts stay ~tens/s (matching the
+production query log) while sessions pile into the thousands.
+
+Usage: retry_spiral.py <tasks_per_sec> <duration_s> [conn_timeout_s] [retries]
+"""
+import os, random, sys, threading, time
+from collections import Counter
+import psycopg2
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+HOST = os.environ.get("PGHOST", "localhost")
+PASS = os.environ["PGPASSWORD"]
+USER = os.environ.get("PGUSER", "pgadmin")
+DB = os.environ.get("PGDATABASE", "postgres")
+
+RATE = float(sys.argv[1]) if len(sys.argv) > 1 else 80.0
+DURATION = int(sys.argv[2]) if len(sys.argv) > 2 else 600
+CONN_TIMEOUT = int(sys.argv[3]) if len(sys.argv) > 3 else 5
+RETRIES = int(sys.argv[4]) if len(sys.argv) > 4 else 2
+MAX_INFLIGHT = 1500  # per-process client-side cap (OS limits)
+
+DSN = (f"host={HOST} port=5432 "
+       f"user={USER} dbname={DB} password={PASS} sslmode=require "
+       f"connect_timeout={CONN_TIMEOUT}")
+
+HOT_NS = ["ns:0", "ns:1", "ns:2"]
+stats = Counter(); lock = threading.Lock(); stop = threading.Event()
+inflight = [0]
+
+def task():
+    with lock: inflight[0] += 1
+    try:
+        for attempt in range(RETRIES + 1):
+            if stop.is_set(): return
+            try:
+                t0 = time.time()
+                conn = psycopg2.connect(DSN)
+                dt = time.time() - t0
+                conn.autocommit = True
+                try:
+                    with conn.cursor() as cur:
+                        ns = random.choice(HOT_NS) if random.random() < 0.55 else f"ns:{3+random.randrange(100000)}"
+                        cur.execute('INSERT INTO "public"."store_stream" (scope, seq, key, record, event_ms, part_month) '
+                                    "VALUES (%s,%s,%s,%s,%s,%s)",
+                                    (ns, random.randrange(10**15), 'k', psycopg2.Binary(os.urandom(1200)),
+                                     int(time.time()*1000), '2026-07-01'))
+                    with lock:
+                        stats['insert_ok'] += 1
+                        stats['conn_ms_sum'] += int(dt*1000)
+                finally:
+                    conn.close()
+                return
+            except psycopg2.OperationalError:
+                with lock: stats['conn_fail_retry'] += 1
+                # immediate retry (typical naive app behavior)
+        with lock: stats['task_gave_up'] += 1
+    finally:
+        with lock: inflight[0] -= 1
+
+threading.stack_size(512*1024)
+t0 = time.time()
+gen_interval = 1.0 / RATE
+next_t = time.time()
+last_ok = 0
+
+while time.time() - t0 < DURATION and not stop.is_set():
+    now = time.time()
+    if now >= next_t:
+        next_t += gen_interval
+        with lock: cur_if = inflight[0]
+        if cur_if < MAX_INFLIGHT:
+            threading.Thread(target=task, daemon=True).start()
+        else:
+            with lock: stats['client_saturated'] += 1
+    else:
+        time.sleep(min(0.005, next_t - now))
+    # periodic report
+    if int(now - t0) % 20 == 0 and now - t0 - int(now - t0) < 0.01:
+        with lock:
+            c = dict(stats); ifl = inflight[0]
+        ok = c.get('insert_ok', 0)
+        avg = c.get('conn_ms_sum', 0)//max(ok, 1)
+        print(f"[{int(now-t0):4d}s] inflight={ifl:5d} insert_rate={(ok-last_ok)/20:6.1f}/s "
+              f"ok={ok} retries={c.get('conn_fail_retry',0)} gaveup={c.get('task_gave_up',0)} "
+              f"client_sat={c.get('client_saturated',0)} avg_conn_ms={avg}", flush=True)
+        last_ok = ok
+        time.sleep(0.02)
+
+stop.set()
+print("SPIRAL_DONE", dict(stats), "inflight_final", inflight[0], flush=True)

--- a/postgresql/cpu100-connection-churn-reproduction/schema.sql
+++ b/postgresql/cpu100-connection-churn-reproduction/schema.sql
@@ -42,6 +42,13 @@ CREATE TABLE IF NOT EXISTS public.store_stream_offsets (
   consumed_seq bigint NOT NULL DEFAULT 0
 );
 
+-- 시퀀스 카운터 (replay.py의 op_seq_counter가 사용)
+CREATE TABLE IF NOT EXISTS public.seq_counter (
+  id bigint NOT NULL,
+  update_time timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT seq_counter_pk PRIMARY KEY (id)
+);
+
 -- 2) 부모 제약/인덱스만 정의 (자식에 자동 전파/생성)
 ALTER TABLE public.store_kv
   ADD CONSTRAINT store_kv_pkey PRIMARY KEY (scope, key, part_month);

--- a/postgresql/cpu100-connection-churn-reproduction/schema.sql
+++ b/postgresql/cpu100-connection-churn-reproduction/schema.sql
@@ -1,0 +1,99 @@
+-- 1) 부모 테이블만 정의 (파티션 테이블)
+CREATE TABLE IF NOT EXISTS public.store_kv (
+  scope text NOT NULL,
+  key text NOT NULL,
+  value bytea NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  part_month date NOT NULL DEFAULT (date_trunc('month', now() AT TIME ZONE 'UTC'))::date,
+  ttl_policy text,
+  ttl_policy_hash text,
+  expires_at timestamptz
+) PARTITION BY RANGE (part_month);
+
+CREATE TABLE IF NOT EXISTS public.store_stream (
+  scope text NOT NULL,
+  seq bigint NOT NULL,
+  key text,
+  record bytea NOT NULL,
+  event_ms bigint,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  part_month date NOT NULL DEFAULT (date_trunc('month', now() AT TIME ZONE 'UTC'))::date,
+  ttl_policy text,
+  ttl_policy_hash text,
+  expires_at timestamptz
+) PARTITION BY RANGE (part_month);
+
+CREATE TABLE IF NOT EXISTS public.store_sorted_set (
+  scope text NOT NULL,
+  member text NOT NULL,
+  score double precision NOT NULL DEFAULT 0.0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  part_month date NOT NULL DEFAULT (date_trunc('month', now() AT TIME ZONE 'UTC'))::date,
+  ttl_policy text,
+  ttl_policy_hash text,
+  expires_at timestamptz
+) PARTITION BY RANGE (part_month);
+
+-- 비파티션 테이블
+CREATE TABLE IF NOT EXISTS public.store_stream_offsets (
+  scope text NOT NULL,
+  consumed_seq bigint NOT NULL DEFAULT 0
+);
+
+-- 2) 부모 제약/인덱스만 정의 (자식에 자동 전파/생성)
+ALTER TABLE public.store_kv
+  ADD CONSTRAINT store_kv_pkey PRIMARY KEY (scope, key, part_month);
+ALTER TABLE public.store_stream
+  ADD CONSTRAINT store_stream_pkey PRIMARY KEY (scope, seq, part_month);
+ALTER TABLE public.store_sorted_set
+  ADD CONSTRAINT store_sorted_set_pkey PRIMARY KEY (scope, member, part_month);
+ALTER TABLE public.store_stream_offsets
+  ADD CONSTRAINT store_stream_offsets_pkey PRIMARY KEY (scope);
+
+CREATE INDEX IF NOT EXISTS idx_store_kv_expires_at_due ON public.store_kv (expires_at) WHERE expires_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_store_kv_scope ON public.store_kv (scope);
+CREATE INDEX IF NOT EXISTS idx_store_kv_scope_prefix ON public.store_kv (scope text_pattern_ops);
+CREATE INDEX IF NOT EXISTS idx_store_kv_updated_at ON public.store_kv (updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_store_stream_created_at ON public.store_stream (created_at);
+CREATE INDEX IF NOT EXISTS idx_store_stream_expires_at_due ON public.store_stream (expires_at) WHERE expires_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_store_stream_scope ON public.store_stream (scope);
+CREATE INDEX IF NOT EXISTS idx_store_stream_scope_prefix ON public.store_stream (scope text_pattern_ops);
+
+CREATE INDEX IF NOT EXISTS idx_store_sorted_set_expires_at_due ON public.store_sorted_set (expires_at) WHERE expires_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_store_sorted_set_scope_prefix ON public.store_sorted_set (scope text_pattern_ops);
+CREATE INDEX IF NOT EXISTS idx_store_sorted_set_ns_score_member ON public.store_sorted_set (scope, score, member);
+CREATE INDEX IF NOT EXISTS idx_store_sorted_set_updated_at ON public.store_sorted_set (updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_store_stream_offsets_scope_prefix ON public.store_stream_offsets (scope text_pattern_ops);
+
+-- 3) 월 파티션 자동 생성 함수
+CREATE OR REPLACE FUNCTION public.ensure_monthly_partitions(
+  p_parent_table text,
+  p_from_month date,
+  p_to_month date
+) RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_month date := date_trunc('month', p_from_month)::date;
+  v_end   date := date_trunc('month', p_to_month)::date;
+  v_child text;
+BEGIN
+  WHILE v_month < v_end LOOP
+    v_child := format('%s_%s', p_parent_table, to_char(v_month, 'YYYY_MM'));
+    EXECUTE format(
+      'CREATE TABLE IF NOT EXISTS public.%I PARTITION OF public.%I FOR VALUES FROM (%L) TO (%L)',
+      v_child, p_parent_table, v_month, (v_month + interval '1 month')::date
+    );
+    v_month := (v_month + interval '1 month')::date;
+  END LOOP;
+END;
+$$;
+
+-- 4) 필요한 범위 한번에 생성 (예: 2025-11 ~ 2026-11)
+SELECT public.ensure_monthly_partitions('store_kv',         '2025-11-01', '2026-11-01');
+SELECT public.ensure_monthly_partitions('store_stream',        '2025-11-01', '2026-11-01');
+SELECT public.ensure_monthly_partitions('store_sorted_set', '2025-11-01', '2026-11-01');

--- a/postgresql/cpu100-connection-churn-reproduction/session_storm.py
+++ b/postgresql/cpu100-connection-churn-reproduction/session_storm.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Reproduce production evidence: ~5000 PostgreSQL sessions, write-only workload (§6.1 mix).
+Direct 5432 connections (session count is server-side evidence, so bypassing pgbouncer pool).
+Most sessions idle; each does a write every --idle seconds on hot scopes.
+Usage: session_storm.py <num_conns> <duration_s> <mean_idle_s>
+"""
+import os, random, sys, threading, time
+from collections import Counter
+import psycopg2
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+HOST = os.environ.get("PGHOST", "localhost")
+PASS = os.environ["PGPASSWORD"]
+USER = os.environ.get("PGUSER", "pgadmin")
+DB = os.environ.get("PGDATABASE", "postgres")
+DSN = (f"host={HOST} port=5432 "
+       f"user={USER} dbname={DB} password={PASS} sslmode=require "
+       f"connect_timeout=20")
+
+N = int(sys.argv[1]) if len(sys.argv) > 1 else 4800
+DURATION = int(sys.argv[2]) if len(sys.argv) > 2 else 900
+IDLE = float(sys.argv[3]) if len(sys.argv) > 3 else 5.0
+
+HOT_NS = ["ns:0", "ns:1", "ns:2"]
+def pick_ns():
+    return random.choice(HOT_NS) if random.random() < 0.55 else f"ns:{3+random.randrange(100000)}"
+
+stats = Counter(); lock = threading.Lock(); stop = threading.Event()
+connected = [0]
+
+def one_write(cur, st):
+    r = random.random()
+    if r < 0.23:
+        st['seq'] = st.get('seq', random.randrange(10**9)) + 1
+        cur.execute('INSERT INTO "public"."store_stream" (scope, seq, key, record, event_ms, part_month) VALUES (%s,%s,%s,%s,%s,%s)',
+                    (pick_ns(), st['seq']*1000+random.randrange(1000), 'k', psycopg2.Binary(os.urandom(1200)),
+                     int(time.time()*1000), '2026-07-01')); return 'log_ins'
+    elif r < 0.43:
+        cur.execute('INSERT INTO "public"."store_kv" (scope, key, value) VALUES (%s,%s,%s)',
+                    (pick_ns(), f"sk:{random.randrange(10**9)}", psycopg2.Binary(os.urandom(1800)))); return 'kv_ins'
+    elif r < 0.61:
+        cur.execute('INSERT INTO "public"."store_stream_offsets" (scope, consumed_seq) VALUES (%s,%s) '
+                    'ON CONFLICT (scope) DO UPDATE SET consumed_seq = GREATEST("public"."store_stream_offsets".consumed_seq, EXCLUDED.consumed_seq)',
+                    (pick_ns(), random.randrange(10**8))); return 'off_ups'
+    elif r < 0.78:
+        cur.execute('INSERT INTO "public"."store_kv" (scope, key, value) VALUES (%s,%s,%s) '
+                    'ON CONFLICT (scope, key, part_month) DO UPDATE SET value=EXCLUDED.value, updated_at=NOW()',
+                    (pick_ns(), f"hotkey:{random.randrange(5000)}", psycopg2.Binary(os.urandom(1800)))); return 'kv_ups'
+    elif r < 0.90:
+        cur.execute('INSERT INTO "public"."store_sorted_set" (scope, member, score) VALUES (%s,%s,%s) ON CONFLICT DO NOTHING',
+                    (pick_ns(), f"sm:{random.randrange(10**9)}", random.random()*1e6)); return 'ss_ins'
+    else:
+        cur.execute('INSERT INTO "public"."store_sorted_set" (scope, member, score) VALUES (%s,%s,%s) '
+                    'ON CONFLICT (scope, member, part_month) DO UPDATE SET score=EXCLUDED.score, updated_at=NOW()',
+                    (pick_ns(), f"hotmember:{random.randrange(5000)}", random.random()*1e6)); return 'ss_ups'
+
+def worker(delay):
+    time.sleep(delay)  # ramp
+    st = {}
+    conn = None
+    while not stop.is_set():
+        try:
+            if conn is None or conn.closed:
+                conn = psycopg2.connect(DSN); conn.autocommit = True
+                with lock: connected[0] += 1
+            time.sleep(random.expovariate(1.0/IDLE))
+            if stop.is_set(): break
+            with conn.cursor() as cur:
+                k = one_write(cur, st)
+            with lock: stats[k] += 1
+        except Exception as e:
+            with lock:
+                stats['err:'+type(e).__name__] += 1
+                if conn is not None: connected[0] -= 1
+            conn = None
+            time.sleep(2)
+
+threading.stack_size(512*1024)
+t0 = time.time()
+RAMP = 180.0
+threads = []
+for i in range(N):
+    t = threading.Thread(target=worker, args=(RAMP*i/N,), daemon=True)
+    t.start(); threads.append(t)
+    if i % 500 == 0: time.sleep(0.05)
+
+last = 0
+try:
+    while time.time() - t0 < DURATION:
+        time.sleep(30)
+        with lock: cur = dict(stats); c = connected[0]
+        tot = sum(v for k,v in cur.items() if not k.startswith('err'))
+        errs = {k:v for k,v in cur.items() if k.startswith('err')}
+        print(f"[{int(time.time()-t0):5d}s] conns={c:5d} qps={(tot-last)/30:7.1f} total={tot:8d} errs={errs}", flush=True)
+        last = tot
+finally:
+    stop.set()
+    print("STORM_DONE", dict(stats), flush=True)

--- a/postgresql/cpu100-connection-churn-reproduction/session_storm.py
+++ b/postgresql/cpu100-connection-churn-reproduction/session_storm.py
@@ -72,6 +72,9 @@ def worker(delay):
             with lock:
                 stats['err:'+type(e).__name__] += 1
                 if conn is not None: connected[0] -= 1
+            if conn is not None:
+                try: conn.close()
+                except Exception: pass
             conn = None
             time.sleep(2)
 


### PR DESCRIPTION
Closes #41

## 요약

운영 PostgreSQL(4 vCore) CPU 100% 장애를 동일 사양·스키마·데이터 규모의 Azure 재현 환경에서 실측 검증한 문서와 부하 스크립트를 추가합니다.

## 주요 내용

- **재현 성공**: 커넥션 수립(backend fork + TLS) 비용 폭주 시나리오 3종에서 운영 관측 4종(CPU 100% / 세션 ~5,000 / 메모리 안정 / write-only 로그 ~20 QPS)과 일치하는 상태 재현
  - 재시도 나선: 200 tasks/s 수준 부하로 CPU 99.2%
  - 커넥션 churn: 동시 커넥터 480으로 CPU 99.7%
  - Pool thrashing: 풀 구성 상태에서도 CPU 96%
- **원인 후보 및 검증 우선순위** (§0): per-request connect 재시도 나선 > pool thrashing > 5432 직결, 각 후보에 운영 확인 항목 병기
- **기각된 가설 7건** (§6, 접힘 처리): 쿼리 믹스 단독 부하, 미기록 SELECT, 메모리 고갈, idle 세션 오버헤드, PG 버전/SSL, read replica, bloat 단독
- **부하 스크립트 10종 + 스키마** 동봉 (자격증명은 환경변수, README에 문서 § 매핑)

## 리뷰어 참고

- 재현 환경 실측값이며 프로덕션 확정 진단이 아님을 문서 Scope에 명시
- 실험 매트릭스 전체는 부록 A 참고